### PR TITLE
Prevent component sharing state across apps/instances

### DIFF
--- a/webapp/Component.js
+++ b/webapp/Component.js
@@ -82,7 +82,7 @@ sap.ui.define([
 			this._oViewModel = this.getModel("viewModel");
 			
 			//Initialize view model data
-			this._oViewModel.setData(models.viewModelData);
+			this._oViewModel.setData(models.createViewModelData());
 			
 			// Initialize search and sort fields
 			this._initSearchFields();

--- a/webapp/manifest.json
+++ b/webapp/manifest.json
@@ -94,8 +94,7 @@
 					"defaultBindingMode": "OneWay",
 					"defaultCountMode": "Request"
 				},
-				"dataSource": "Z_COMMON_SRV",
-				"preload": true
+				"dataSource": "Z_COMMON_SRV"
 			}
 		},
 		"resources": {

--- a/webapp/model/models.js
+++ b/webapp/model/models.js
@@ -13,136 +13,138 @@ sap.ui.define([
 			return oModel;
 		},
 
-		viewModelData: {
-			state: {
-				busy: false
-			},
-			// Fields used in currently open item popover or in the create item dialog.
-			// Note: each field will be given additional properties:
-			// 'value', 'valueState' and 'valueStateText' by the _resetFields method. 
-			// In the case of the Item Popover, controls are bound directly to the oODataModel
-			// and the 'value' is not used.
-			fields: {
-				material: {
-					label: "Part Number",
-					initialValue: "",
-					required: item => !item.description,
-					canSearch: true,
-					canSort: true
+		createViewModelData() {
+			return {
+				state: {
+					busy: false
 				},
-				description: {
-					label: "Part Description",
-					initialValue: "",
-					required: item => !item.material,
-					canSearch: true,
-					canSort: true
+				// Fields used in currently open item popover or in the create item dialog.
+				// Note: each field will be given additional properties:
+				// 'value', 'valueState' and 'valueStateText' by the _resetFields method. 
+				// In the case of the Item Popover, controls are bound directly to the oODataModel
+				// and the 'value' is not used.
+				fields: {
+					material: {
+						label: "Part Number",
+						initialValue: "",
+						required: item => !item.description,
+						canSearch: true,
+						canSort: true
+					},
+					description: {
+						label: "Part Description",
+						initialValue: "",
+						required: item => !item.material,
+						canSearch: true,
+						canSort: true
+					},
+					type: {
+						label: "Order type",
+						initialValue: "",
+						required: false,
+						noValueState: true,
+						canSort: true
+					},
+					objectkey: {
+						label: "Order id",
+						initialValue: "",
+						canSearch: true,
+						required: item => item.type !== "",
+						canSort: true
+					},
+					line: {
+						label: "Item id",
+						initialValue: "",
+						canSort: true
+					},
+					quantity: {
+						initialValue: null,
+						label: "Quantity required",
+						required: item => !item.unlimitedQuantity,
+						canSort: true
+					},
+					unlimitedQuantity: {
+						initialValue: false,
+						label: "Unlimited",
+						required: false
+					},
+					quantityIssued: {
+						initialValue: "0",
+						label: "Quantity issued"
+					},
+					uom: {
+						initialValue: "EA",
+						label: "Unit of measure",
+						required: true
+					},
+					dueDate: {
+						label: "Due date",
+						initialValue: null,
+						required: false,
+						canSort: true
+					},
+					deliverTo: {
+						label: "Deliver to",
+						initialValue: "",
+						required: false,
+						canSort: true
+					},
+					comments: {
+						label: "Comments",
+						initialValue: "",
+						required: false
+					},
+					enteredByName: {
+						label: "Contact",
+						initialValue: "",
+						canSearch: true,
+						canSort: true
+					},
+					supplierName: {
+						label: "Supplier",
+						initialValue: "",
+						canSearch: true,
+						canSort: false
+					}
 				},
-				type: {
-					label: "Order type",
-					initialValue: "",
-					required: false,
-					noValueState: true,
-					canSort: true
+				itemPopover: {
+					hasError: false // Can't get formatter to refire on change to value state in fields so using this redundant prop
 				},
-				objectkey: {
-					label: "Order id",
-					initialValue: "",
-					canSearch: true,
-					required: item => item.type !== "",
-					canSort: true
+				create: {
+					message: {
+						type: MessageType.None,
+						text: ""
+					}
 				},
-				line: {
-					label: "Item id",
-					initialValue: "",
-					canSort: true
+				selectedCount: 0,
+				referenceTypes: [{
+					id: "",
+					description: ""
+				}, {
+					id: "P",
+					description: "Purchase Order"
+				}, {
+					id: "S",
+					description: "Sales Order"
+				}, {
+					id: "D",
+					description: "Production Order"
+				}],
+				search: {
+					value: "",
+					fields: [] // populated in _initSearchFields()
 				},
-				quantity: {
-					initialValue: null,
-					label: "Quantity required",
-					required: item => !item.unlimitedQuantity,
-					canSort: true
+				sort: {
+					fields: [], // populated in _initSortFields()
+					activeFieldCount: 0 // populated in _updateSortActiveFieldCount()
 				},
-				unlimitedQuantity: {
-					initialValue: false,
-					label: "Unlimited",
-					required: false
-				},
-				quantityIssued: {
-					initialValue: "0",
-					label: "Quantity issued"
-				},
-				uom: {
-					initialValue: "EA",
-					label: "Unit of measure",
-					required: true
-				},
-				dueDate: {
-					label: "Due date",
-					initialValue: null,
-					required: false,
-					canSort: true
-				},
-				deliverTo: {
-					label: "Deliver to",
-					initialValue: "",
-					required: false,
-					canSort: true
-				},
-				comments: {
-					label: "Comments",
-					initialValue: "",
-					required: false
-				},
-				enteredByName: {
-					label: "Contact",
-					initialValue: "",
-					canSearch: true,
-					canSort: true
-				},
-				supplierName: {
-					label: "Supplier",
-					initialValue: "",
-					canSearch: true,
-					canSort: false
+				settings: {
+					allowCreate: true,
+					allowUpdate: true,
+					allowUserFiltering: true,
+					allowNavToGR: true
 				}
-			},
-			itemPopover: {
-				hasError: false // Can't get formatter to refire on change to value state in fields so using this redundant prop
-			},
-			create: {
-				message: {
-					type: MessageType.None,
-					text: ""
-				}
-			},
-			selectedCount: 0,
-			referenceTypes: [{
-				id: "",
-				description: ""
-			}, {
-				id: "P",
-				description: "Purchase Order"
-			}, {
-				id: "S",
-				description: "Sales Order"
-			}, {
-				id: "D",
-				description: "Production Order"
-			}],
-			search: {
-				value: "",
-				fields: [] // populated in _initSearchFields()
-			},
-			sort: {
-				fields: [], // populated in _initSortFields()
-				activeFieldCount: 0 // populated in _updateSortActiveFieldCount()
-			},
-			settings: {
-				allowCreate: true,
-				allowUpdate: true,
-				allowUserFiltering: true,
-				allowNavToGR: true
-			}
+			};
 		}
 	};
 });


### PR DESCRIPTION
+ Remove model preload - not supported in 1.38 (warning in WebIde and gives console error in deployed version). 