### PR TITLE
Fix item popover form not reactive on field change

### DIFF
--- a/webapp/Component.js
+++ b/webapp/Component.js
@@ -860,6 +860,7 @@ sap.ui.define([
 						this._oViewModel.setProperty(sValueStateTextPath, "");
 					}
 					this._resetErrorFlagItemOverflowPopover();
+					this._oODataModel.refresh(); // Needed to make form reactive - e.g. on change to unlimited qty
 					MessageToast.show("Item updated.");
 					//this._resetODataModel();
 


### PR DESCRIPTION
@acookoz The backend change to not set complete flag if quantity is zero fixed the root problem of not being able to unset "unlimited quantity". However, in the front end we lost reactivity at some stage so changes to the "Unlimited quantity" flag weren't being reflected in the form.  ie. if you unset it, it would update successfully but the quantity field was still read-only. I've added a single  call to `oODataModel.refresh()` which fixes the form but I'm not sure if this might have other potential side effects that we don't want so I'm running it past you.